### PR TITLE
Implement `lt`, `lte`, `gt`, `gte`, `between` comparators.

### DIFF
--- a/server/utils/__tests__/is-protected-entity.spec.js
+++ b/server/utils/__tests__/is-protected-entity.spec.js
@@ -91,7 +91,7 @@ describe('isProtectedEntity', () => {
     expect(result).toBe(true);
   });
 
-  it('should return `false` if entity attribute does not match the `has` rule', () => {
+  it('should return `false` if entity attribute does not match the `hasNot` rule', () => {
     const entity = { roles: ['admin', 'user'] };
     const rules = [['roles', 'hasNot', 'admin']];
     const result = isProtectedEntity(entity, rules);
@@ -113,6 +113,80 @@ describe('isProtectedEntity', () => {
     const result = isProtectedEntity(entity, rules);
 
     expect(result).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `lt` rule', () => {
+    const entity = { attribute: 1 };
+    const rules = [['attribute', 'lt', 2]];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `lt` rule', () => {
+    const entity = { attribute: 1 };
+
+    expect(isProtectedEntity(entity, [['attribute', 'lt', 1]])).toBe(false);
+    expect(isProtectedEntity(entity, [['attribute', 'lt', 0]])).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `lte` rule', () => {
+    const entity = { attribute: 1 };
+
+    expect(isProtectedEntity(entity, [['attribute', 'lte', 1]])).toBe(true);
+    expect(isProtectedEntity(entity, [['attribute', 'lte', 2]])).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `lte` rule', () => {
+    const entity = { attribute: 1 };
+    const rules = [['attribute', 'lte', 0]];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `gt` rule', () => {
+    const entity = { attribute: 1 };
+    const rules = [['attribute', 'gt', 0]];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `gt` rule', () => {
+    const entity = { attribute: 1 };
+    expect(isProtectedEntity(entity, [['attribute', 'gt', 1]])).toBe(false);
+    expect(isProtectedEntity(entity, [['attribute', 'gt', 2]])).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `gte` rule', () => {
+    const entity = { attribute: 1 };
+
+    expect(isProtectedEntity(entity, [['attribute', 'gte', 1]])).toBe(true);
+    expect(isProtectedEntity(entity, [['attribute', 'gte', 0]])).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `gte` rule', () => {
+    const entity = { attribute: 1 };
+    const rules = [['attribute', 'gte', 2]];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `between` rule', () => {
+    const entity = { attribute: 1 };
+
+    expect(isProtectedEntity(entity, [['attribute', 'between', [0, 2]]])).toBe(true);
+    expect(isProtectedEntity(entity, [['attribute', 'between', [0, 1]]])).toBe(true);
+    expect(isProtectedEntity(entity, [['attribute', 'between', [1, 2]]])).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `between` rule', () => {
+    const entity = { attribute: 1 };
+
+    expect(isProtectedEntity(entity, [['attribute', 'between', [-2, 0]]])).toBe(false);
+    expect(isProtectedEntity(entity, [['attribute', 'between', [2, 4]]])).toBe(false);
   });
 
   it('should return `false` if the provided `comparator` is unknown', () => {

--- a/server/utils/__tests__/is-protected-entity.spec.js
+++ b/server/utils/__tests__/is-protected-entity.spec.js
@@ -155,6 +155,7 @@ describe('isProtectedEntity', () => {
 
   it('should return `false` if entity attribute does not match the `gt` rule', () => {
     const entity = { attribute: 1 };
+
     expect(isProtectedEntity(entity, [['attribute', 'gt', 1]])).toBe(false);
     expect(isProtectedEntity(entity, [['attribute', 'gt', 2]])).toBe(false);
   });
@@ -208,7 +209,7 @@ describe('isProtectedEntity', () => {
     expect(result).toBe(false);
   });
 
-  it('should return `true` if at least one of the provided rules is truly', () => {
+  it('should return `true` if at least one of the provided rules is truthy', () => {
     const entity = { attribute: 1 };
     const rules = [
       ['attribute', 'is', 0],
@@ -216,6 +217,6 @@ describe('isProtectedEntity', () => {
     ];
     const result = isProtectedEntity(entity, rules);
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 });

--- a/server/utils/__tests__/is-protected-entity.spec.js
+++ b/server/utils/__tests__/is-protected-entity.spec.js
@@ -196,4 +196,26 @@ describe('isProtectedEntity', () => {
 
     expect(result).toBe(false);
   });
+
+  it('should return `false` if all the provided rules are falsy', () => {
+    const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'is', 0],
+      ['attribute', 'is', 2],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `true` if at least one of the provided rules is truly', () => {
+    const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'is', 0],
+      ['attribute', 'is', 1],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(false);
+  });
 });

--- a/server/utils/is-protected-entity.js
+++ b/server/utils/is-protected-entity.js
@@ -7,6 +7,11 @@ const COMPARATOR_ACTION_STRATEGY = {
   notIn: (value, attr) => !value.includes(attr),
   has: (value, attr) => attr.includes(value),
   hasNot: (value, attr) => !attr.includes(value),
+  lt: (value, attr) => attr < value,
+  lte: (value, attr) => attr <= value,
+  gt: (value, attr) => attr > value,
+  gte: (value, attr) => attr >= value,
+  between: (value, attr) => attr >= value[0] && attr <= value[1],
   matches: (value, attr) => RegExp(value).test(attr),
 };
 


### PR DESCRIPTION
type: **minor**

## Changes
- Implement `lt`, `lte`, `gt`, `gte`, `between` comparators. Cover it with tests.
- Add tests to cover the `rules.some()` method usage. 

@mattmilburn Could you review the PR, please?