### PR TITLE
Date comparators

### DIFF
--- a/server/utils/__tests__/is-protected-entity.spec.js
+++ b/server/utils/__tests__/is-protected-entity.spec.js
@@ -117,7 +117,10 @@ describe('isProtectedEntity', () => {
 
   it('should return `true` if entity attribute matches the `lt` rule', () => {
     const entity = { attribute: 1 };
-    const rules = [['attribute', 'lt', 2]];
+    const rules = [
+      ['attribute', 'lt', 2],
+      ['attribute', 'lt', 10],
+    ];
     const result = isProtectedEntity(entity, rules);
 
     expect(result).toBe(true);
@@ -125,21 +128,32 @@ describe('isProtectedEntity', () => {
 
   it('should return `false` if entity attribute does not match the `lt` rule', () => {
     const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'lt', 0],
+      ['attribute', 'lt', 1],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'lt', 1]])).toBe(false);
-    expect(isProtectedEntity(entity, [['attribute', 'lt', 0]])).toBe(false);
+    expect(result).toBe(false);
   });
 
   it('should return `true` if entity attribute matches the `lte` rule', () => {
     const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'lte', 1],
+      ['attribute', 'lte', 2],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'lte', 1]])).toBe(true);
-    expect(isProtectedEntity(entity, [['attribute', 'lte', 2]])).toBe(true);
+    expect(result).toBe(true);
   });
 
   it('should return `false` if entity attribute does not match the `lte` rule', () => {
     const entity = { attribute: 1 };
-    const rules = [['attribute', 'lte', 0]];
+    const rules = [
+      ['attribute', 'lte', -1],
+      ['attribute', 'lte', 0],
+    ];
     const result = isProtectedEntity(entity, rules);
 
     expect(result).toBe(false);
@@ -147,7 +161,10 @@ describe('isProtectedEntity', () => {
 
   it('should return `true` if entity attribute matches the `gt` rule', () => {
     const entity = { attribute: 1 };
-    const rules = [['attribute', 'gt', 0]];
+    const rules = [
+      ['attribute', 'gt', -1],
+      ['attribute', 'gt', 0],
+    ];
     const result = isProtectedEntity(entity, rules);
 
     expect(result).toBe(true);
@@ -155,21 +172,32 @@ describe('isProtectedEntity', () => {
 
   it('should return `false` if entity attribute does not match the `gt` rule', () => {
     const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'gt', 1],
+      ['attribute', 'gt', 2],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'gt', 1]])).toBe(false);
-    expect(isProtectedEntity(entity, [['attribute', 'gt', 2]])).toBe(false);
+    expect(result).toBe(false);
   });
 
   it('should return `true` if entity attribute matches the `gte` rule', () => {
     const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'gte', 0],
+      ['attribute', 'gte', 1],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'gte', 1]])).toBe(true);
-    expect(isProtectedEntity(entity, [['attribute', 'gte', 0]])).toBe(true);
+    expect(result).toBe(true);
   });
 
   it('should return `false` if entity attribute does not match the `gte` rule', () => {
     const entity = { attribute: 1 };
-    const rules = [['attribute', 'gte', 2]];
+    const rules = [
+      ['attribute', 'gte', 2],
+      ['attribute', 'gte', 10],
+    ];
     const result = isProtectedEntity(entity, rules);
 
     expect(result).toBe(false);
@@ -177,22 +205,34 @@ describe('isProtectedEntity', () => {
 
   it('should return `true` if entity attribute matches the `between` rule', () => {
     const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'between', [0, 2]],
+      ['attribute', 'between', [0, 1]],
+      ['attribute', 'between', [1, 2]],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'between', [0, 2]]])).toBe(true);
-    expect(isProtectedEntity(entity, [['attribute', 'between', [0, 1]]])).toBe(true);
-    expect(isProtectedEntity(entity, [['attribute', 'between', [1, 2]]])).toBe(true);
+    expect(result).toBe(true);
   });
 
   it('should return `false` if entity attribute does not match the `between` rule', () => {
     const entity = { attribute: 1 };
+    const rules = [
+      ['attribute', 'between', [-2, 0]],
+      ['attribute', 'between', [2, 4]],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'between', [-2, 0]]])).toBe(false);
-    expect(isProtectedEntity(entity, [['attribute', 'between', [2, 4]]])).toBe(false);
+    expect(result).toBe(false);
   });
 
   it('should return `true` if entity attribute matches the `after` rule', () => {
     const entity = { attribute: '2020-01-01' };
-    const rules = [['attribute', 'after', '2019-12-31']];
+    const rules = [
+      ['attribute', 'after', 'Tue, 31 Dec 2019 19:12:27 GMT'],
+      ['attribute', 'after', '2019-12-31T19:12:27.873Z'],
+      ['attribute', 'after', '2019-12-31'],
+    ];
     const result = isProtectedEntity(entity, rules);
 
     expect(result).toBe(true);
@@ -200,14 +240,24 @@ describe('isProtectedEntity', () => {
 
   it('should return `false` if entity attribute does not match the `after` rule', () => {
     const entity = { attribute: '2019-12-31' };
+    const rules = [
+      ['attribute', 'after', 'Tue, 31 Dec 2019 19:12:27 GMT'],
+      ['attribute', 'after', '2019-12-31T19:12:27.873Z'],
+      ['attribute', 'after', '2019-12-31'],
+      ['attribute', 'after', '2020-01-01'],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'after', '2019-12-31']])).toBe(false);
-    expect(isProtectedEntity(entity, [['attribute', 'after', '2020-01-01']])).toBe(false);
+    expect(result).toBe(false);
   });
 
   it('should return `true` if entity attribute matches the `before` rule', () => {
     const entity = { attribute: '2019-12-31' };
-    const rules = [['attribute', 'before', '2020-01-01']];
+    const rules = [
+      ['attribute', 'before', 'Tue, 31 Dec 2019 19:12:27 GMT'],
+      ['attribute', 'before', '2019-12-31T19:12:27.873Z'],
+      ['attribute', 'before', '2020-01-01'],
+    ];
     const result = isProtectedEntity(entity, rules);
 
     expect(result).toBe(true);
@@ -215,9 +265,93 @@ describe('isProtectedEntity', () => {
 
   it('should return `false` if entity attribute does not match the `before` rule', () => {
     const entity = { attribute: '2020-01-01' };
+    const rules = [
+      ['attribute', 'before', 'Tue, 31 Dec 2019 19:12:27 GMT'],
+      ['attribute', 'before', '2019-12-31T19:12:27.873Z'],
+      ['attribute', 'before', '2019-12-31'],
+      ['attribute', 'before', '2020-01-01'],
+    ];
+    const result = isProtectedEntity(entity, rules);
 
-    expect(isProtectedEntity(entity, [['attribute', 'before', '2019-12-31']])).toBe(false);
-    expect(isProtectedEntity(entity, [['attribute', 'before', '2020-01-01']])).toBe(false);
+    expect(result).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `day` rule', () => {
+    const entity = { attribute: '2020-01-01' };
+    const rules = [
+      ['attribute', 'day', 'Wed, 01 Jan 2020 19:12:27 GMT'],
+      ['attribute', 'day', '2020-01-01T19:12:27.873Z'],
+      ['attribute', 'day', '2020-01-01'],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `day` rule', () => {
+    const entity = { attribute: '2019-01-01' };
+    const rules = [
+      ['attribute', 'day', 'Wed, 01 Jan 2020 19:12:27 GMT'],
+      ['attribute', 'day', '2020-01-01T19:12:27.873Z'],
+      ['attribute', 'day', '2020-01-01'],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `month` rule', () => {
+    const entity = { attribute: '2020-01-01' };
+    const rules = [
+      ['attribute', 'month', 'Fri, 31 Jan 2020 19:12:27 GMT'],
+      ['attribute', 'month', '2020-01-31T19:12:27.873Z'],
+      ['attribute', 'month', '2020-01-31'],
+      ['attribute', 'month', '2020-01'],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `month` rule', () => {
+    const entity = { attribute: '2019-01-01' };
+    const rules = [
+      ['attribute', 'month', 'Wed, 01 Jan 2020 19:12:27 GMT'],
+      ['attribute', 'month', '2020-01-01T19:12:27.873Z'],
+      ['attribute', 'month', '2020-01-01'],
+      ['attribute', 'month', '2020-01'],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `year` rule', () => {
+    const entity = { attribute: '2020-01-01' };
+    const rules = [
+      ['attribute', 'year', 'Tue, 01 Dec 2020 19:12:27 GMT'],
+      ['attribute', 'year', '2020-12-01T19:12:27.873Z'],
+      ['attribute', 'year', '2020-12-01'],
+      ['attribute', 'year', '2020-12'],
+      ['attribute', 'year', '2020'],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `year` rule', () => {
+    const entity = { attribute: '2019-01-01' };
+    const rules = [
+      ['attribute', 'year', 'Wed, 01 Jan 2020 19:12:27 GMT'],
+      ['attribute', 'year', '2020-01-01T19:12:27.873Z'],
+      ['attribute', 'year', '2020-01-01'],
+      ['attribute', 'year', '2020-01'],
+      ['attribute', 'year', '2020'],
+    ];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(false);
   });
 
   it('should return `false` if the provided `comparator` is unknown', () => {

--- a/server/utils/__tests__/is-protected-entity.spec.js
+++ b/server/utils/__tests__/is-protected-entity.spec.js
@@ -190,6 +190,36 @@ describe('isProtectedEntity', () => {
     expect(isProtectedEntity(entity, [['attribute', 'between', [2, 4]]])).toBe(false);
   });
 
+  it('should return `true` if entity attribute matches the `after` rule', () => {
+    const entity = { attribute: '2020-01-01' };
+    const rules = [['attribute', 'after', '2019-12-31']];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `after` rule', () => {
+    const entity = { attribute: '2019-12-31' };
+
+    expect(isProtectedEntity(entity, [['attribute', 'after', '2019-12-31']])).toBe(false);
+    expect(isProtectedEntity(entity, [['attribute', 'after', '2020-01-01']])).toBe(false);
+  });
+
+  it('should return `true` if entity attribute matches the `before` rule', () => {
+    const entity = { attribute: '2019-12-31' };
+    const rules = [['attribute', 'before', '2020-01-01']];
+    const result = isProtectedEntity(entity, rules);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if entity attribute does not match the `before` rule', () => {
+    const entity = { attribute: '2020-01-01' };
+
+    expect(isProtectedEntity(entity, [['attribute', 'before', '2019-12-31']])).toBe(false);
+    expect(isProtectedEntity(entity, [['attribute', 'before', '2020-01-01']])).toBe(false);
+  });
+
   it('should return `false` if the provided `comparator` is unknown', () => {
     const entity = { type: 'user' };
     const rules = [['name', 'unknown_comparator', 'user']];

--- a/server/utils/is-protected-entity.js
+++ b/server/utils/is-protected-entity.js
@@ -1,19 +1,28 @@
 'use strict';
 
 const COMPARATOR_ACTION_STRATEGY = {
+  // Equality.
   is: (value, attr) => value === attr,
   isNot: (value, attr) => value !== attr,
-  in: (value, attr) => value.includes(attr),
-  notIn: (value, attr) => !value.includes(attr),
+
+  // Contains.
   has: (value, attr) => attr.includes(value),
   hasNot: (value, attr) => !attr.includes(value),
-  lt: (value, attr) => attr < value,
-  lte: (value, attr) => attr <= value,
+  in: (value, attr) => value.includes(attr),
+  notIn: (value, attr) => !value.includes(attr),
+
+  // Greater than or equal to.
+  between: (value, attr) => attr >= value[0] && attr <= value[1],
   gt: (value, attr) => attr > value,
   gte: (value, attr) => attr >= value,
-  between: (value, attr) => attr >= value[0] && attr <= value[1],
-  before: (value, attr) => new Date(attr) < new Date(value),
+  lt: (value, attr) => attr < value,
+  lte: (value, attr) => attr <= value,
+
+  // Dates.
   after: (value, attr) => new Date(attr) > new Date(value),
+  before: (value, attr) => new Date(attr) < new Date(value),
+
+  // Regular expression.
   matches: (value, attr) => RegExp(value).test(attr),
 };
 

--- a/server/utils/is-protected-entity.js
+++ b/server/utils/is-protected-entity.js
@@ -21,6 +21,23 @@ const COMPARATOR_ACTION_STRATEGY = {
   // Dates.
   after: (value, attr) => new Date(attr) > new Date(value),
   before: (value, attr) => new Date(attr) < new Date(value),
+  day: (value, attr) => {
+    const d1 = new Date(attr);
+    const d2 = new Date(value);
+
+    return (
+      d1.getUTCDate() === d2.getUTCDate() &&
+      d1.getUTCMonth() === d2.getUTCMonth() &&
+      d1.getUTCFullYear() === d2.getUTCFullYear()
+    );
+  },
+  month: (value, attr) => {
+    const d1 = new Date(attr);
+    const d2 = new Date(value);
+
+    return d1.getUTCMonth() === d2.getUTCMonth() && d1.getUTCFullYear() === d2.getUTCFullYear();
+  },
+  year: (value, attr) => new Date(attr).getUTCFullYear() === new Date(value).getUTCFullYear(),
 
   // Regular expression.
   matches: (value, attr) => RegExp(value).test(attr),

--- a/server/utils/is-protected-entity.js
+++ b/server/utils/is-protected-entity.js
@@ -12,6 +12,8 @@ const COMPARATOR_ACTION_STRATEGY = {
   gt: (value, attr) => attr > value,
   gte: (value, attr) => attr >= value,
   between: (value, attr) => attr >= value[0] && attr <= value[1],
+  before: (value, attr) => new Date(attr) < new Date(value),
+  after: (value, attr) => new Date(attr) > new Date(value),
   matches: (value, attr) => RegExp(value).test(attr),
 };
 


### PR DESCRIPTION
Add new date comparators (including tests) for `before`, `after`, `day`, `month`, and `year`.